### PR TITLE
add instruction for Debian system

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Please refer the link for a full list of affected platforms.
    * rpm   --> "rpm -i -nodeps iclsClient<version>.<arch>.rpm"
    * alien --> "alien -i -nodeps –-script iclsClient<version>.<arch>.rpm"
    * yum   --> "yum install iclsClient<version>.<arch>.rpm"
+   * apt   --> "alien --to-deb iclsClient<version>.<arch>.rpm && dpkg -i iclsClient<version>.<arch>.deb"
 9. Please make sure system wide proxy has been setup and the platform is connected.
 9. After installing above dependencies a reboot is required. 
 


### PR DESCRIPTION
Small edit to add instruction for Debian (apt based) distribution.

Tested on a NUC7i3BNB with Proxmox

```bash
root@pve:~/keys# export LD_LIBRARY_PATH=/opt/Intel/iclsClient/lib/
root@pve:~/keys# ./Intel-SA-00086-Recovery-Tool
Retrieving RSA/ ECC EK Certificate from iCLS backend
Recovery successful. Attempting to read new EK certificate from NV
Reading RSA EK Certificate from NV Index
Downloading intermediate and root CA certificates
Validating EK certificate chain
Downloading certificate revocation list information
Checking certificate revocation list
Endorsement key certificate download/ validation complete
root@pve:~/keys#
```